### PR TITLE
add script to generate ShrinkIt file if nulib2 is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ out
 # Directory mounted in Virtual ][ as a ProDOS volume
 mount
 
+# Shrinkit file
+A2D.SHK
+
 # OS-specific files
 .DS_Store

--- a/res/shk.sh
+++ b/res/shk.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Run this from the top level directory
+
+# Use nulib2 to create a ShrinkIt! archive for distribution
+# https://nulib.com
+
+set -e
+
+PNULIB2=`which nulib2`
+PNULIB2="${PNULIB2:-$HOME/dev/nulib2/nulib2/nulib2}"
+NULIB2="${NULIB2:-$PNULIB2}"
+
+set -e
+source "res/util.sh"
+
+tempdir=$(mktemp -d -t SHK)
+[ -d "${tempdir}" ] || (cecho red "cannot make tempdir"; exit 1)
+
+mkdir -p "${tempdir}/desk.acc" || (cecho red "permission denied"; exit 1)
+
+rm -f A2D.SHK
+
+function mount_f1 {
+    srcdir="$2"
+    dstdir="$3"
+    uppercase=$(echo "$1" | tr /a-z/ /A-Z/)
+    src="$srcdir/out/$1.built"
+    dst="$dstdir/$uppercase#F10000"
+    cp "$src" "$dst" \
+        && (cecho green "wrote $dst" ) \
+        || (cecho red "failed to write $dst" ; return 1)
+}
+
+function mount_sys {
+    srcdir="$2"
+    dstdir="$3"
+    uppercase=$(echo "$1" | tr /a-z/ /A-Z/)
+    src="$srcdir/out/$1.SYS"
+    dst="$dstdir/$uppercase#FF0000"
+    cp "$src" "$dst" \
+        && (cecho green "wrote $dst" ) \
+        || (cecho red "failed to write $dst" ; return 1)
+}
+
+echo "Copying files to ${tempdir}/"
+mkdir -p mount
+
+mount_f1 "desktop2" "desktop" "${tempdir}"
+mount_sys "desktop.system" "desktop.system" "${tempdir}"
+mount_sys "ram.system" "ram.system" "${tempdir}"
+
+mkdir -p "${tempdir}/desk.acc"
+for file in $(cat desk.acc/TARGETS); do
+    mount_f1 "$file" "desk.acc" "${tempdir}/desk.acc"
+done
+
+mkdir -p "${tempdir}/preview"
+for file in $(cat preview/TARGETS); do
+    mount_f1 "$file" "preview" "${tempdir}/preview"
+done
+cdir=`pwd`
+cd "${tempdir}"
+nulib2 aer "${cdir}/A2D.SHK" * || (cecho red "failed to write ${cdir}/A2D.SHK" ; return 1)
+cd "${cdir}"
+rm -rf "${tempdir}"
+ls -l A2D.SHK


### PR DESCRIPTION
using mount.sh as a template, I created shk.sh which will generate an A2D.SHK.  ShrinkIt archives are especially useful when moving stuff around via AppleTalk.

requires nulib2 which easily compiles on any Unix-like system.