### PR TITLE
Fix IRQ handling for MLI calls.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ out
 # Directory mounted in Virtual ][ as a ProDOS volume
 mount
 
+# Shrinkit file
+A2D.SHK
+
 # OS-specific files
 .DS_Store

--- a/desktop/desktop_main.s
+++ b/desktop/desktop_main.s
@@ -859,8 +859,6 @@ L46AE:  jsr     disable_eject_menu_item
 .proc MLI_RELAY
         sty     call
         stax    params
-        php
-        sei
         sta     ALTZPOFF
         sta     ROMIN2
         jsr     MLI
@@ -870,7 +868,6 @@ params: .addr   dummy0000
         tax
         lda     LCBANK1
         lda     LCBANK1
-        plp
         txa
         rts
 .endproc

--- a/desktop/loader.s
+++ b/desktop/loader.s
@@ -265,21 +265,13 @@ start:
         bpl     :-
 
         ;; Open this system file
-        php
-        sei
         MLI_CALL OPEN, open_params
-        plp
-        and     #$FF            ; ???
         beq     :+
         brk                     ; crash
 :       lda     open_params::ref_num
         sta     set_mark_params::ref_num
         sta     read_params::ref_num
-        php
-        sei
         MLI_CALL SET_MARK, set_mark_params
-        plp
-        and     #$FF            ; ???
         beq     :+
         brk                     ; crash
 :       lda     #0
@@ -290,11 +282,7 @@ loop:   lda     segment_num
         bne     continue
 
         ;; Close and invoke DeskTop init routine
-        php
-        sei
         MLI_CALL CLOSE, close_params
-        plp
-        and     #$FF            ; ???
         beq     :+
         brk                     ; crash
 :       jmp     DESKTOP_INIT
@@ -304,11 +292,7 @@ continue:
         tax
         copy16  segment_addr_table,x, read_params::data_buffer
         copy16  segment_size_table,x, read_params::request_count
-        php
-        sei
         MLI_CALL READ, read_params
-        plp
-        and     #$FF            ; ???
         beq     :+
         brk                     ; crash
 :       ldx     segment_num

--- a/desktop/ovl1.s
+++ b/desktop/ovl1.s
@@ -81,8 +81,6 @@ start:  lda     #$80
         sty     call
         sta     params
         stx     params+1
-        php
-        sei
         sta     ALTZPOFF
         lda     ROMIN2
         jsr     MLI
@@ -92,7 +90,6 @@ params: .addr   0
         sta     ALTZPON
         lda     LCBANK1
         lda     LCBANK1
-        plp
         txa
 self:   bne     self            ; hang on error?
         rts

--- a/desktop/ovl1a.s
+++ b/desktop/ovl1a.s
@@ -120,13 +120,9 @@ loop:   lda     (src),y
 .proc MLI_RELAY
         sty     call
         stax    params
-        php
-        sei
         jsr     MLI
 call:   .byte   0
 params: .addr   0
-        plp
-        and     #$FF
 self:   bne     self            ; hang if fails
         rts
 .endproc

--- a/desktop/ovl1c.s
+++ b/desktop/ovl1c.s
@@ -630,8 +630,6 @@ on_line_buffer:
 .proc MLI_RELAY
         sty     call
         stax    params
-        php
-        sei
         sta     ALTZPOFF
         lda     ROMIN2
         jsr     MLI
@@ -641,7 +639,6 @@ params: .addr   0
         sta     ALTZPON
         lda     LCBANK1
         lda     LCBANK1
-        plp
         txa
         rts
 .endproc

--- a/desktop/ovl2.s
+++ b/desktop/ovl2.s
@@ -488,6 +488,8 @@ L0D8D:  .byte   0
 
         PAD_TO $E00
 
+; This is (probably) a Disk II formatter routine
+
 L0E00:  php
         sei
         jsr     L0E3A
@@ -1035,8 +1037,6 @@ L124A:  .byte   $00
 .proc MLI_RELAY
         sty     call
         stax    params
-        php
-        sei
         sta     ALTZPOFF
         lda     ROMIN2
         jsr     MLI
@@ -1046,7 +1046,6 @@ params: .addr   0
         sta     ALTZPON
         lda     LCBANK1
         lda     LCBANK1
-        plp
         txa
         rts
 .endproc

--- a/desktop/ovl3.s
+++ b/desktop/ovl3.s
@@ -1424,8 +1424,6 @@ L9DC8:  .byte   0
 .proc MLI_RELAY
         sty     call
         stax    params
-        php
-        sei
         sta     ALTZPOFF
         sta     ROMIN2
         jsr     MLI
@@ -1435,7 +1433,6 @@ params: .addr   0
         tax
         lda     LCBANK1
         lda     LCBANK1
-        plp
         txa
         rts
 .endproc

--- a/desktop/ovl4.s
+++ b/desktop/ovl4.s
@@ -844,8 +844,6 @@ L5993:  .byte   0
 .proc MLI_RELAY
         sty     call
         stax    params
-        php
-        sei
         sta     ALTZPOFF
         lda     ROMIN2
         jsr     MLI
@@ -855,7 +853,6 @@ params: .addr   0
         tax
         lda     LCBANK1
         lda     LCBANK1
-        plp
         txa
         rts
 .endproc

--- a/res/shk.sh
+++ b/res/shk.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Run this from the top level directory
+
+# Use nulib2 to create a ShrinkIt! archive for distribution
+# https://nulib.com
+
+set -e
+
+PNULIB2=`which nulib2`
+PNULIB2="${PNULIB2:-$HOME/dev/nulib2/nulib2/nulib2}"
+NULIB2="${NULIB2:-$PNULIB2}"
+
+set -e
+source "res/util.sh"
+
+tempdir=$(mktemp -d -t SHK)
+[ -d "${tempdir}" ] || (cecho red "cannot make tempdir"; exit 1)
+
+mkdir -p "${tempdir}/desk.acc" || (cecho red "permission denied"; exit 1)
+
+rm -f A2D.SHK
+
+function mount_f1 {
+    srcdir="$2"
+    dstdir="$3"
+    uppercase=$(echo "$1" | tr /a-z/ /A-Z/)
+    src="$srcdir/out/$1.built"
+    dst="$dstdir/$uppercase#F10000"
+    cp "$src" "$dst" \
+        && (cecho green "wrote $dst" ) \
+        || (cecho red "failed to write $dst" ; return 1)
+}
+
+function mount_sys {
+    srcdir="$2"
+    dstdir="$3"
+    uppercase=$(echo "$1" | tr /a-z/ /A-Z/)
+    src="$srcdir/out/$1.SYS"
+    dst="$dstdir/$uppercase#FF0000"
+    cp "$src" "$dst" \
+        && (cecho green "wrote $dst" ) \
+        || (cecho red "failed to write $dst" ; return 1)
+}
+
+echo "Copying files to ${tempdir}/"
+mkdir -p mount
+
+mount_f1 "desktop2" "desktop" "${tempdir}"
+mount_sys "desktop.system" "desktop.system" "${tempdir}"
+mount_sys "ram.system" "ram.system" "${tempdir}"
+
+mkdir -p "${tempdir}/desk.acc"
+for file in $(cat desk.acc/TARGETS); do
+    mount_f1 "$file" "desk.acc" "${tempdir}/desk.acc"
+done
+
+mkdir -p "${tempdir}/preview"
+for file in $(cat preview/TARGETS); do
+    mount_f1 "$file" "preview" "${tempdir}/preview"
+done
+cdir=`pwd`
+cd "${tempdir}"
+nulib2 aer "${cdir}/A2D.SHK" * || (cecho red "failed to write ${cdir}/A2D.SHK" ; return 1)
+cd "${cdir}"
+rm -rf "${tempdir}"
+ls -l A2D.SHK


### PR DESCRIPTION
As discussed in #129, ProDOS is capable of handling its own interrupts.   This saves bytes (3-4 per MLI call) and corrects remaining known issues on the Apple IIe Card.