### PR TITLE
DeskTop/Disk Copy: Make Disk II identification more robust.

### DIFF
--- a/desktop/init.s
+++ b/desktop/init.s
@@ -819,8 +819,8 @@ process_volume:
 
         ldy     device_index
         lda     DEVLST,y
-        and     #$0F            ; unit number low nibble; 0 = 16-sector Disk II
-        beq     select_template ; BUG: That's not valid per ProDOS TN21
+        jsr     main::IsDiskII
+        beq     select_template ; skip
         ldx     device_index
         jsr     remove_device
         jmp     next

--- a/disk_copy/main.s
+++ b/disk_copy/main.s
@@ -104,12 +104,12 @@ params:  .res    3
         ldx     auxlc::dest_drive_index
         lda     auxlc::drive_unitnum_table,x
         sta     unit_number
-        and     #$0F            ; unit number low nibble; 0 = 16-sector Disk II
-        beq     disk_ii         ; BUG: That's not valid per ProDOS TN21
+        jsr     auxlc::IsDiskII
+        beq     disk_ii
 
         ;; Get driver address
         lda     unit_number
-        jsr     unit_number_to_driver_address
+        jsr     unit_number_to_driver_address ; sets $06, Z=1 if firmware
 
         lda     #DRIVER_COMMAND_FORMAT
         sta     DRIVER_COMMAND
@@ -135,7 +135,7 @@ unit_number:
         ptr := $6
 
         sta     unit_num
-        jsr     unit_number_to_driver_address
+        jsr     unit_number_to_driver_address ; sets $06, Z=1 if firmware
         bne     done            ; not firmware; can't tell if SmartPort or not
 
         lda     #$00            ; Point at $Cn00

--- a/inc/prodos.inc
+++ b/inc/prodos.inc
@@ -38,6 +38,10 @@ BLOCK_SIZE      = $200
 ;;; the slot and drive, as the high nibble is DSSS.
 UNIT_NUM_MASK   = $F0
 
+;;; Mask off just the slot bits from a unit number. Used when
+;;; constructing $Cn00 pointer to probe firmware.
+UNIT_NUM_SLOT_MASK      = %01110000 ; 0SSS0000
+
 ;;; ============================================================
 ;;; MLI Calls
 ;;; ============================================================

--- a/lib/is_diskii.s
+++ b/lib/is_diskii.s
@@ -1,0 +1,86 @@
+;;; ============================================================
+;;; Test if a device is a Disk II, following ProDOS rules.
+;;; Only 16-sector Disk II devices are considered, as ProDOS
+;;; does not support 13-sector Disk II devices.
+;;; Inputs: unit number in A
+;;; Outputs: Z=1 if Disk II, Z=0 otherwise
+;;; Notes: A,X,Y trashed, $06 preserved
+
+.proc IsDiskII
+        ptr := $06
+
+        tay
+        lda     ptr             ; save $06
+        pha
+        lda     ptr+1
+        pha
+        tya
+
+        ;; Get device driver address
+        and     #UNIT_NUM_MASK
+        lsr
+        lsr
+        lsr
+        tax
+        copy16  DEVADR,x, ptr
+
+        ;; Is the driver in firmware? (i.e. is driver in $CnXX)
+        lda     ptr
+        and     #$F0
+        cmp     #$C0
+        beq     not_diskii      ; yes, so not Disk II
+
+        ;; Check slot. Per Technical Note: ProDOS #21, Disk II
+        ;; devices are never remapped. In general we can't trust
+        ;; the slot bits in the unit number, due to remapping.
+        ;; But if the slot *actually* contains a Disk II device,
+        ;; we know it *wasn't* remapped so the slot bits were
+        ;; correct. Q.E.D.
+
+        tya
+        and     #UNIT_NUM_SLOT_MASK ; 0SSS0000
+        lsr                         ; 00SSS000
+        lsr                         ; 000SSS00
+        lsr                         ; 0000SSS0
+        lsr                         ; 00000SSS
+        ora     #$C0                ; $Cn
+        sta     ptr+1
+        lda     #0
+        sta     ptr             ; ptr = $Cn00
+
+        ;; Does this slot contain an actual ProDOS device? We
+        ;; Need to test this in case a device was remapped into
+        ;; this slot. Look for the signature bytes.
+        ldy     #$01            ; $Cn01 = $20 ?
+        lda     (ptr),y
+        cmp     #$20
+        bne     not_diskii
+        ldy     #$03            ; $Cn03 = $00 ?
+        lda     (ptr),y
+        cmp     #$00
+        bne     not_diskii
+        ldy     #$05            ; $Cn05 = $03 ?
+        lda     (ptr),y
+        cmp     #$03
+        bne     not_diskii
+
+        ;; Slot contains a ProDOS device. But is it a Disk II?
+        ldy     #$FF            ; $CnFF = $00 is a 16-sector Disk II
+        lda     (ptr),y
+        cmp     #$00
+        beq     finish          ; Yes, finish with A=0
+
+        ;; NOTE: $CnFF = $FF would signify a 13-sector Disk II, which
+        ;; ProDOS does not support, so we don't probe for that.
+
+not_diskii:
+        lda     #$FF            ; nope
+
+finish: tay
+        pla                     ; restore $06
+        sta     ptr+1
+        pla
+        sta     ptr
+        tya
+        rts
+.endproc


### PR DESCRIPTION
Both DeskTop and Disk Copy used an obsolete heuristic that the low byte
of a unit number signified a device type, with $x0 meaning Disk II.
Per ProDOS 8 Technical Note #21, that's invalid; the low nibble is
just derived from the $CnFE firmware byte from the device, or
something arbitrary.

Further, I'd misinterpreted the meaning of part of TN#21 which said
to use the SSS bytes of the unit number. I thought that was bogus
for non-firmware drivers, but it's valid for Disk II devices which have
non-firmware drivers! If there's a firmware driver, and the SSS bits
point at a ProDOS device that's a Disk II, it *is* valid since Disk II
devices are never remapped.

Note that there are still fiddly cases; if the SSS bits don't point
at a ProDOS device, we can't further identify it. If the SSS bits do
point at a ProDOS device, then in theory it shouldn't be remapped.

Anyway, this means we can construct a rigorous "does this unit number
refer to a Disk II?" method, and use it in DeskTop's icon creation,
the Format/Erase device naming and format logic, and Disk Copy's
device-specific logic, removing reliance on a "device type nibble"

Reference:
http://www.1000bit.it/support/manuali/apple/technotes/pdos/tn.pdos.21.html