### PR TITLE
Added nix flake for dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774799055,
+        "narHash": "sha256-Tsq9BCz0q47ej1uFF39m4tuhcwru/ls6vCCJzutEpaw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "107cba9eb4a8d8c9f8e9e61266d78d340867913a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  outputs =
+    { self, nixpkgs }:
+    let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      cc65-git = pkgs.cc65.overrideAttrs (_: {
+        version = "git";
+        src = pkgs.fetchFromGitHub {
+          owner = "cc65";
+          repo = "cc65";
+          rev = "80ff9d3f4d6f1a4711ede8b6250374955ed7adb6";
+          hash = "sha256-NGsnD9BocDmkZuqp5XRY+h+462tm15kRYeF9SVyvUBg=";
+        };
+      });
+    in
+    {
+      devShells.x86_64-linux.default = pkgs.mkShell {
+        packages = [ cc65-git ];
+      };
+    };
+}


### PR DESCRIPTION
Added a nix flake providing a development shell with the correct cc65 version. To use run the following command with nix installed.

`nix develop`