### PR TITLE
phasor detect fix for cycle delay

### DIFF
--- a/src/lib/detect_phasor.s
+++ b/src/lib/detect_phasor.s
@@ -67,9 +67,14 @@ loop:   lda     (ptr),Y
         sec
         sbc     tmp
         cmp     #($100 - 8)
+        beq     next
+        ;; A real Phasor's native-mode timer reads consume an extra count
+        ;; (c/o mb-audit), and accelerators like the FASTChip //e also
+        ;; stretch the delta; accept it.
+        cmp     #($100 - 9)
         bne     fail
 
-        dex
+next:   dex
         bne     loop
 
         pla


### PR DESCRIPTION
The real phasor is one cycle delayed. This patch adds a check on the additional cycle, so a2d can detect the real thing and the virtual thing that may not be perfect.