### PR TITLE
Change clc to sec for cursor position calculation

### DIFF
--- a/src/mgtk/mgtk.s
+++ b/src/mgtk/mgtk.s
@@ -4229,7 +4229,7 @@ finish:
 
         ;; Compute rows to draw
         lda     cursor_pos::ycoord
-        clc
+        sec
         sbc     cursor_hotspot_y
         sta     cursor_y1
         clc


### PR DESCRIPTION
Makes cursor render 1 pixel too high.
See also `.macpack generic`.